### PR TITLE
Requiring IMDSv2 for aws launch config

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -296,6 +296,11 @@ resource "aws_launch_configuration" "workers" {
     aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly,
     aws_iam_role_policy_attachment.workers_additional_policies
   ]
+  
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 }
 
 resource "random_pet" "workers" {


### PR DESCRIPTION
Fix for: Launch configuration uses IMDSv1 which vulnerable to SSRF

# PR o'clock

## Description
I tried to use your Module but there is a security issue reported by terrascan:
```
	Description    :	Launch configuration uses IMDSv1 which vulnerable to SSRF
	File           :	../../../../../tmp/jqpxh5/workers.tf
	Line           :	162
	Severity       :	HIGH
```
https://www.accurics.com/blog/security-blog/aws-cloud-security-protect-ssrf/

### Checklist

- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
